### PR TITLE
Small change to docs: don't include protocol when supplying bucket name in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bucket. This is alpha software that is still under development, so your
 % bagcat config
 aws_access_key_id: skljfs
 aws_secret_access_key: sldkfjslkjf
-bucket: s3://my-bags
+bucket: my-bags
 
 % bagcat list
 


### PR DESCRIPTION
Config seems to only want the name of the bucket without any protocol, e.g., "s3://"

If the bucket name is supplied incorrectly, `bagcat list` hangs and then spits out a connection error:

`socket.gaierror: [Errno 8] nodename nor servname provided, or not known`

Maybe error handling could supply a useful message, e.g., 'Did you supply the name of a valid bucket?' or some such …
